### PR TITLE
Add Office document preview and update docs for AI & File Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Most small businesses need 80% of enterprise features at 10% of the cost. **Clov
 - Soft delete with recovery
 - Bulk operations
 - Content-addressed storage (deduplication)
+- **File Groups** (virtual collections)
+- **Company Folders** (org-wide sharing)
 
 </td>
 <td width="33%" valign="top">
@@ -127,6 +129,18 @@ Most small businesses need 80% of enterprise features at 10% of the cost. **Clov
 - Sandboxed with permission grants
 
 </td>
+<td width="33%" valign="top">
+
+#### AI Features
+- Document summarization
+- Question & Answer on docs
+- Multi-provider support
+- Self-hosted LLM support
+- Usage limits & monitoring
+
+</td>
+</tr>
+<tr>
 <td width="33%" valign="top">
 
 #### Storage Backends
@@ -459,6 +473,8 @@ All require `Authorization: Bearer <token>` header.
 | `/api/settings` | Compliance, branding, SMTP, blocked extensions |
 | `/api/security/alerts` | List, resolve, dismiss alerts |
 | `/api/audit-logs` | Query with filters, export |
+| `/api/groups` | File groups CRUD, add/remove files |
+| `/api/ai` | Summarization, Q&A, usage stats |
 
 > See [backend/README.md](backend/README.md) for complete API documentation.
 
@@ -488,10 +504,13 @@ Security is a core focus of ClovaLink. Key measures include:
 - [x] Extension system
 - [x] Security alerts dashboard
 - [x] Email notifications for alerts
+- [x] AI-powered document features (summarization, Q&A)
+- [x] File Groups (virtual collections)
+- [x] Company Folders (org-wide sharing)
+- [x] Office document preview (Excel, PowerPoint)
 - [ ] Mobile apps (iOS/Android)
 - [ ] WebDAV support
 - [ ] Real-time collaboration
-- [ ] AI-powered file tagging
 - [ ] Slack/Teams integration
 
 ---

--- a/backend/crates/api/src/main.rs
+++ b/backend/crates/api/src/main.rs
@@ -614,6 +614,7 @@ async fn main() {
         .route("/api/files/{company_id}", get(handlers::list_files))
         .route("/api/files/{company_id}/export", get(handlers::export_files))
         .route("/api/download/{company_id}/{file_id}", get(handlers::download_file))
+        .route("/api/preview/{company_id}/{file_id}", get(handlers::preview_office_file))
         .route("/api/folders/{company_id}", post(handlers::create_folder))
         .route("/api/files/{company_id}/rename", post(handlers::rename_file))
         .route("/api/files/{company_id}/delete", post(handlers::delete_file))

--- a/docs/wiki/AI-Features.md
+++ b/docs/wiki/AI-Features.md
@@ -1,0 +1,250 @@
+# AI Features
+
+ClovaLink includes AI-powered document features that enable intelligent summarization, question answering, and semantic search across your files.
+
+## Overview
+
+The AI module provides:
+
+| Feature | Description |
+|---------|-------------|
+| **Document Summarization** | Generate concise summaries of documents (PDF, Word, text files) |
+| **Question & Answer** | Ask questions about document content and get AI-powered answers |
+| **Semantic Search** | Search across documents using natural language queries |
+
+## Supported AI Providers
+
+ClovaLink supports multiple AI providers, allowing you to choose based on your compliance requirements, cost preferences, or existing vendor relationships.
+
+### Cloud Providers
+
+| Provider | Models | Notes |
+|----------|--------|-------|
+| **OpenAI** | GPT-4o-mini, GPT-4o | Most popular, good balance of cost/quality |
+| **Anthropic** | Claude 3 Haiku, Sonnet, Opus | Strong on safety and long documents |
+| **Google** | Gemini 1.5 Flash, Pro | Good for multimodal tasks |
+| **Azure OpenAI** | GPT-4o-mini, GPT-4o | Enterprise-grade with Azure compliance |
+| **Mistral AI** | Mistral Small, Large | European provider, GDPR-friendly |
+| **Cohere** | Command-R, Command-R+ | Strong enterprise search capabilities |
+
+### Self-Hosted / Custom
+
+For organizations requiring complete data control, ClovaLink supports self-hosted LLM servers:
+
+| Server | Example Endpoint |
+|--------|------------------|
+| **Ollama** | `http://localhost:11434/v1` |
+| **vLLM** | `http://localhost:8000/v1` |
+| **LocalAI** | `http://localhost:8080/v1` |
+| **Text Generation Inference** | `http://localhost:8080` |
+
+When using a self-hosted provider, configure:
+- **Custom Endpoint URL**: The base URL of your LLM server
+- **Model Name**: The model identifier (e.g., `llama3`, `mistral`, `codellama`)
+
+## Configuration
+
+### Enabling AI Features
+
+1. Navigate to **Settings > AI Features** (Admin/SuperAdmin only)
+2. Toggle **Enable AI Features**
+3. Select your AI provider
+4. Enter your API key (encrypted at rest)
+5. Click **Save**
+
+### Self-Hosted Configuration
+
+When selecting "Self-Hosted / Custom":
+
+```
+AI Provider: [Self-Hosted / Custom]
+
+Custom Endpoint URL: http://localhost:11434/v1
+Model Name: llama3
+```
+
+### Role-Based Access
+
+Control which roles can use AI features:
+
+| Role | Default Access |
+|------|----------------|
+| SuperAdmin | ✅ Enabled |
+| Admin | ✅ Enabled |
+| Manager | ❌ Disabled |
+| Employee | ❌ Disabled |
+
+Admins can enable AI access for Manager and Employee roles in the settings.
+
+## Usage Limits
+
+Prevent runaway costs with configurable limits:
+
+| Limit Type | Default | Description |
+|------------|---------|-------------|
+| **Monthly Token Limit** | 100,000 | Maximum tokens per month |
+| **Daily Request Limit** | 100 | Maximum AI requests per day |
+
+Usage resets automatically:
+- Daily limits reset at midnight UTC
+- Monthly limits reset on the 1st of each month
+
+### Monitoring Usage
+
+View real-time usage statistics in **Settings > AI Features > Usage History**:
+- Tokens used today/this month
+- Request counts
+- Per-user activity log
+- Success/failure rates
+
+## Using AI Features
+
+### Document Summarization
+
+1. Open a file preview (PDF, Word, or text document)
+2. Click the **Summarize** button (sparkles icon)
+3. View the AI-generated summary
+
+Summaries are cached per file, so subsequent requests are instant.
+
+### Question & Answer
+
+1. Open a file preview
+2. Click the **Ask AI** button
+3. Type your question (e.g., "What are the key dates mentioned?")
+4. Get an AI-powered answer based on the document content
+
+### Supported File Types
+
+| Format | Extension | Notes |
+|--------|-----------|-------|
+| PDF | `.pdf` | Text extracted automatically |
+| Word | `.docx` | Full text content |
+| Excel | `.xlsx`, `.xls` | All sheets combined |
+| PowerPoint | `.pptx` | Slide text extracted |
+| Text | `.txt`, `.md`, `.json` | Direct processing |
+| CSV | `.csv` | Treated as text |
+
+## Caching
+
+AI responses are cached to reduce API costs and improve response times:
+
+| Cache Type | Duration | Invalidation |
+|------------|----------|--------------|
+| Summary | Permanent | When file is modified |
+| Q&A | Session | When file is modified |
+
+**Note**: Cached summaries are provider-agnostic. If you switch from OpenAI to Claude, existing cached summaries will still be served. Delete the file's cached summary to regenerate with the new provider.
+
+## Maintenance Mode
+
+Temporarily disable new AI requests while still serving cached content:
+
+1. Go to **Settings > AI Features**
+2. Enable **Maintenance Mode**
+3. Customize the maintenance message
+4. Users will see cached summaries but cannot make new requests
+
+Useful for:
+- API key rotation
+- Provider migrations
+- Cost control during budget reviews
+
+## Security Considerations
+
+### Data Processing Agreements
+
+Before enabling AI features, ensure you have appropriate agreements with your AI provider:
+
+- **OpenAI**: Enterprise agreements available for HIPAA/SOC2
+- **Azure OpenAI**: Inherits Azure compliance certifications
+- **Self-Hosted**: Complete data control, no external transmission
+
+When enabling AI features, ClovaLink displays a warning reminder about data processing agreements.
+
+### What Data is Sent
+
+| Sent to AI Provider | NOT Sent |
+|---------------------|----------|
+| Document text content | File names |
+| User questions | User identities |
+| | Metadata |
+| | Access logs |
+
+### Audit Logging
+
+All AI operations are logged for compliance:
+
+```
+User: john@company.com
+Action: summarize
+File: contract_2024.pdf
+Provider: openai
+Tokens: 1,247
+Status: success
+Timestamp: 2024-01-15T10:30:00Z
+```
+
+## Troubleshooting
+
+### "AI features are disabled"
+
+- Check that AI is enabled in tenant settings
+- Verify your role has AI access permissions
+
+### "API key required"
+
+- Enter a valid API key in Settings > AI Features
+- Use the "Test Connection" button to verify
+
+### "Rate limit exceeded"
+
+- Wait for limit reset (daily or monthly)
+- Ask admin to increase limits
+- Consider upgrading your AI provider plan
+
+### "Failed to extract text"
+
+- Ensure the file is a supported format
+- Check that the PDF contains text (not just images)
+- For scanned documents, OCR is not currently supported
+
+## API Reference
+
+### Get AI Status
+
+```http
+GET /api/ai/status
+Authorization: Bearer <token>
+```
+
+### Summarize Document
+
+```http
+POST /api/ai/summarize
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "file_id": "uuid",
+  "force_refresh": false
+}
+```
+
+### Ask Question
+
+```http
+POST /api/ai/answer
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "file_id": "uuid",
+  "question": "What are the payment terms?"
+}
+```
+
+---
+
+*See also: [Admin Guide](Admin-Guide) | [Security](Security) | [API Reference](API-Reference)*
+

--- a/docs/wiki/File-Groups.md
+++ b/docs/wiki/File-Groups.md
@@ -1,0 +1,291 @@
+# File Groups
+
+File Groups allow you to organize related files into logical collections without moving them from their original locations. Think of them as virtual folders or tags that group files together for easy access.
+
+## Overview
+
+| Concept | Description |
+|---------|-------------|
+| **File Group** | A named collection of files from anywhere in your file system |
+| **Virtual Organization** | Files remain in their original folders but appear together in the group |
+| **Visibility** | Groups can be department-wide or private to the creator |
+| **Collaboration** | Share related documents as a cohesive package |
+
+## Use Cases
+
+- **Project Collections**: Group all files related to a project across different folders
+- **Client Bundles**: Collect contracts, invoices, and reports for a specific client
+- **Review Packages**: Assemble documents for approval workflows
+- **Personal Organization**: Create private groups for your own workflow
+
+## Creating File Groups
+
+### Method 1: From the Toolbar
+
+1. Navigate to **Files**
+2. Click **New Group** (layers icon)
+3. Enter a group name and optional description
+4. Choose a color for visual identification
+5. Click **Create**
+
+### Method 2: From a File
+
+1. Right-click on any file
+2. Select **Create Group from File**
+3. The file is automatically added to the new group
+
+### Method 3: Multiple Selection
+
+1. Select multiple files (Ctrl/Cmd + click)
+2. Right-click and select **Create Group**
+3. All selected files are added to the new group
+
+## Managing Groups
+
+### Adding Files to a Group
+
+**Drag and Drop:**
+1. Drag any file onto a group card
+2. The file is linked to the group (not moved)
+
+**Context Menu:**
+1. Right-click a file
+2. Select **Add to Group**
+3. Choose from your available groups
+
+### Removing Files from a Group
+
+1. Open the group viewer (click on a group card)
+2. Find the file you want to remove
+3. Click the **Remove from Group** option
+4. The file remains in its original location
+
+### Renaming a Group
+
+1. Right-click on the group card
+2. Select **Rename**
+3. Enter the new name
+4. Press Enter or click Save
+
+### Deleting a Group
+
+1. Right-click on the group card
+2. Select **Delete Group**
+3. Confirm deletion
+
+**Note**: Deleting a group does NOT delete the files. Files remain in their original locations.
+
+## Visibility Modes
+
+Groups have two visibility modes that determine who can see them:
+
+### Department Groups
+
+| Property | Behavior |
+|----------|----------|
+| **Visibility** | All users in the department can see the group |
+| **Location** | Appears in Department Files view |
+| **Use Case** | Team collaboration, shared project collections |
+
+### Private Groups
+
+| Property | Behavior |
+|----------|----------|
+| **Visibility** | Only the creator can see the group |
+| **Location** | Appears in Private Files view |
+| **Use Case** | Personal organization, draft collections |
+
+### Visibility Lock
+
+Groups are **locked to their original visibility** once created:
+- A department group cannot be moved to private files
+- A private group cannot be moved to department files
+- This ensures consistent access control
+
+## Group Locking
+
+Prevent accidental modifications to important groups:
+
+### Lock a Group
+
+1. Right-click on the group card
+2. Select **Lock Group**
+3. The group shows a lock icon
+
+### Locked Group Restrictions
+
+| Action | Allowed? |
+|--------|----------|
+| View files | ✅ Yes |
+| Download files | ✅ Yes |
+| Add files | ❌ No |
+| Remove files | ❌ No |
+| Rename group | ❌ No |
+| Delete group | ❌ No |
+
+### Unlock a Group
+
+Only the user who locked the group (or an Admin) can unlock:
+1. Right-click on the locked group
+2. Select **Unlock Group**
+
+## Company Folder Integration
+
+When a group is placed inside a **Company Folder**, special rules apply:
+
+### Behavior Changes
+
+| Aspect | In Regular Folder | In Company Folder |
+|--------|-------------------|-------------------|
+| **Visibility** | Based on group settings | Visible to all departments |
+| **Edit Access** | Owner and allowed users | Admin/SuperAdmin only |
+| **Icon Display** | Owner avatar | Building icon |
+| **Context Menu** | Full options | View/Download only (non-admins) |
+
+### Moving Groups to Company Folders
+
+Only Admin and SuperAdmin can:
+1. Move a group into a company folder
+2. Edit groups within company folders
+3. Delete groups from company folders
+
+Regular users can only view and download files from groups in company folders.
+
+## Group Viewer
+
+Click on any group card to open the Group Viewer panel:
+
+### Features
+
+- **File List**: See all files in the group with details
+- **Quick Actions**: Preview, download, copy, share individual files
+- **Search**: Filter files within the group
+- **Sorting**: Sort by name, date, size, or type
+
+### Actions Available
+
+| Action | Description |
+|--------|-------------|
+| **Preview** | Open file in preview modal |
+| **Download** | Download file to your device |
+| **Copy** | Copy file to clipboard for pasting elsewhere |
+| **Share** | Create a share link for the file |
+| **Move to Folder** | Move the actual file to a different folder |
+| **Remove from Group** | Unlink file from this group |
+
+## Starring Groups
+
+Mark important groups for quick access:
+
+1. Right-click on a group card
+2. Select **Star Group**
+3. Starred groups appear in your Starred section
+
+## Permissions Summary
+
+| Role | Create Groups | Edit Own | Edit Others | Delete Own | Delete Others |
+|------|---------------|----------|-------------|------------|---------------|
+| Employee | ✅ | ✅ | ❌ | ✅ | ❌ |
+| Manager | ✅ | ✅ | ✅ (dept) | ✅ | ✅ (dept) |
+| Admin | ✅ | ✅ | ✅ | ✅ | ✅ |
+| SuperAdmin | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+## API Reference
+
+### List Groups
+
+```http
+GET /api/groups/{tenant_id}
+Authorization: Bearer <token>
+```
+
+Query parameters:
+- `parent_path`: Filter by folder location
+- `visibility`: Filter by `department` or `private`
+- `department_id`: Filter by specific department
+
+### Create Group
+
+```http
+POST /api/groups/{tenant_id}
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "name": "Q4 Reports",
+  "description": "All Q4 2024 financial reports",
+  "color": "#3B82F6",
+  "visibility": "department"
+}
+```
+
+### Add File to Group
+
+```http
+POST /api/groups/{tenant_id}/{group_id}/files
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "file_ids": ["uuid-1", "uuid-2"]
+}
+```
+
+### Remove File from Group
+
+```http
+DELETE /api/groups/{tenant_id}/{group_id}/files/{file_id}
+Authorization: Bearer <token>
+```
+
+### Lock/Unlock Group
+
+```http
+POST /api/groups/{tenant_id}/{group_id}/lock
+POST /api/groups/{tenant_id}/{group_id}/unlock
+Authorization: Bearer <token>
+```
+
+### Move Group
+
+```http
+PUT /api/groups/{tenant_id}/{group_id}/move
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "target_path": "Projects/2024",
+  "target_visibility": "department"
+}
+```
+
+## Best Practices
+
+1. **Use Descriptive Names**: "Q4 2024 Client Reports" is better than "Reports"
+2. **Add Descriptions**: Help others understand the group's purpose
+3. **Use Colors**: Assign consistent colors (e.g., red for urgent, blue for projects)
+4. **Lock Important Groups**: Prevent accidental changes to finalized collections
+5. **Clean Up**: Delete groups that are no longer needed to reduce clutter
+
+## Troubleshooting
+
+### "Cannot move group to private files"
+
+Groups are locked to their original visibility mode. Create a new private group instead.
+
+### "Cannot edit group in company folder"
+
+Only Admin and SuperAdmin roles can modify groups within company folders.
+
+### "File already in group"
+
+Each file can only be added to a group once. The file is already linked.
+
+### "Cannot remove file - name conflict"
+
+A file with the same name exists in the target location. Rename one of the files first.
+
+---
+
+*See also: [Admin Guide](Admin-Guide) | [Security](Security) | [API Reference](API-Reference)*
+

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -15,6 +15,15 @@ ClovaLink provides secure file storage, sharing, and compliance features for org
 - **Folder Structure** - Hierarchical organization with department isolation
 - **Deduplication** - Content-addressed storage reduces redundant data
 - **S3 Replication** - Async backup/mirror to secondary bucket for DR
+- **File Groups** - Organize files into virtual collections without moving them
+- **Company Folders** - Shared folders visible to all departments
+
+### AI Features
+- **Document Summarization** - AI-generated summaries for PDFs, Word, and text files
+- **Question & Answer** - Ask questions about document content
+- **Multiple Providers** - OpenAI, Anthropic, Google, Azure, Mistral, Cohere
+- **Self-Hosted Support** - Use Ollama, vLLM, or any OpenAI-compatible server
+- **Usage Limits** - Configurable token and request limits per tenant
 
 ### Multi-Tenancy
 - **Isolated Data** - Complete data separation between organizations
@@ -99,6 +108,8 @@ Password: password123
 | [Security](Security) | Security features and configuration |
 | [Virus Scanning](Virus-Scanning) | ClamAV integration and malware protection |
 | [Discord Integration](Discord-Integration) | Discord DM notifications setup |
+| [AI Features](AI-Features) | AI-powered summarization, Q&A, and search |
+| [File Groups](File-Groups) | Organize files into virtual collections |
 
 ## Tech Stack
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,9 @@
     "react-router-dom": "^6.23.0",
     "recharts": "^3.5.1",
     "swapy": "^1.0.5",
-    "tailwind-merge": "^2.3.0"
+    "tailwind-merge": "^2.3.0",
+    "xlsx": "^0.18.5",
+    "jszip": "^3.10.1"
   },
   "devDependencies": {
     "@types/react": "^19.0.0",

--- a/frontend/src/components/FileGroupViewer.tsx
+++ b/frontend/src/components/FileGroupViewer.tsx
@@ -118,10 +118,14 @@ const isPreviewable = (contentType?: string, name?: string) => {
                contentType.startsWith('video/') || 
                contentType.startsWith('audio/') ||
                contentType.includes('pdf') ||
-               contentType.startsWith('text/');
+               contentType.startsWith('text/') ||
+               contentType.includes('spreadsheet') ||
+               contentType.includes('excel') ||
+               contentType.includes('presentation') ||
+               contentType.includes('powerpoint');
     }
     const ext = name?.split('.').pop()?.toLowerCase();
-    return ['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'pdf', 'mp4', 'webm', 'mp3', 'wav', 'txt', 'md'].includes(ext || '');
+    return ['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg', 'pdf', 'mp4', 'webm', 'mp3', 'wav', 'txt', 'md', 'csv', 'xlsx', 'xls', 'pptx', 'ppt'].includes(ext || '');
 };
 
 // Check if file can use AI features (text-based documents only)

--- a/frontend/src/components/FilePreviewModal.tsx
+++ b/frontend/src/components/FilePreviewModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { X, Download, Loader2 } from 'lucide-react';
+import { X, Download, Loader2, FileSpreadsheet, Presentation, ChevronLeft, ChevronRight } from 'lucide-react';
+import * as XLSX from 'xlsx';
 
 interface FilePreviewModalProps {
     isOpen: boolean;
@@ -8,7 +9,19 @@ interface FilePreviewModalProps {
         name: string;
         url: string; // We'll need to generate a presigned URL or serve via proxy
         type: 'image' | 'document' | 'video' | 'audio' | 'folder';
+        size?: number; // File size in bytes for determining client vs server processing
     } | null;
+}
+
+interface ExcelSheet {
+    name: string;
+    data: (string | number | boolean | null)[][];
+}
+
+interface PPTXInfo {
+    slideCount: number;
+    title?: string;
+    author?: string;
 }
 
 export function FilePreviewModal({ isOpen, onClose, file }: FilePreviewModalProps) {
@@ -17,6 +30,13 @@ export function FilePreviewModal({ isOpen, onClose, file }: FilePreviewModalProp
     const [loading, setLoading] = useState(false);
     const [mediaBlobUrl, setMediaBlobUrl] = useState<string | null>(null);
     const [mediaError, setMediaError] = useState<string | null>(null);
+    
+    // Excel preview state
+    const [excelSheets, setExcelSheets] = useState<ExcelSheet[]>([]);
+    const [selectedSheetIndex, setSelectedSheetIndex] = useState(0);
+    
+    // PPTX preview state
+    const [pptxInfo, setPptxInfo] = useState<PPTXInfo | null>(null);
 
     useEffect(() => {
         if (!file) {
@@ -28,21 +48,27 @@ export function FilePreviewModal({ isOpen, onClose, file }: FilePreviewModalProp
             return;
         }
 
-        const isCSV = file.name.toLowerCase().endsWith('.csv');
-        const isText = file.name.toLowerCase().endsWith('.txt') ||
-            file.name.toLowerCase().endsWith('.md') ||
-            file.name.toLowerCase().endsWith('.json') ||
-            file.name.toLowerCase().endsWith('.xml') ||
-            file.name.toLowerCase().endsWith('.log');
+        const fileName = file.name.toLowerCase();
+        const isCSV = fileName.endsWith('.csv');
+        const isText = fileName.endsWith('.txt') ||
+            fileName.endsWith('.md') ||
+            fileName.endsWith('.json') ||
+            fileName.endsWith('.xml') ||
+            fileName.endsWith('.log');
         const isImage = file.type === 'image';
         const isVideo = file.type === 'video';
         const isAudio = file.type === 'audio';
-        const isPDF = file.name.toLowerCase().endsWith('.pdf');
+        const isPDF = fileName.endsWith('.pdf');
+        const isExcel = fileName.endsWith('.xlsx') || fileName.endsWith('.xls');
+        const isPPTX = fileName.endsWith('.pptx') || fileName.endsWith('.ppt');
 
         // Reset states
         setMediaError(null);
         setCsvContent([]);
         setTextContent('');
+        setExcelSheets([]);
+        setSelectedSheetIndex(0);
+        setPptxInfo(null);
 
         // For media files (image, video, audio, PDF), fetch as blob with auth header
         if (isImage || isVideo || isAudio || isPDF) {
@@ -71,6 +97,97 @@ export function FilePreviewModal({ isOpen, onClose, file }: FilePreviewModalProp
                 })
                 .catch(err => {
                     console.error('Failed to load media', err);
+                    setMediaError('Failed to load file. Please try downloading instead.');
+                })
+                .finally(() => setLoading(false));
+        } else if (isExcel) {
+            // Excel file preview using xlsx library
+            setLoading(true);
+            const previewUrl = file.url.includes('?') ? `${file.url}&preview=true` : `${file.url}?preview=true`;
+            fetch(previewUrl, {
+                headers: {
+                    'Authorization': `Bearer ${localStorage.getItem('auth_token') || sessionStorage.getItem('auth_token')}`
+                }
+            })
+                .then(res => {
+                    if (!res.ok) throw new Error('Failed to fetch file');
+                    return res.arrayBuffer();
+                })
+                .then(buffer => {
+                    try {
+                        const workbook = XLSX.read(buffer, { type: 'array' });
+                        const sheets: ExcelSheet[] = workbook.SheetNames.map(name => {
+                            const worksheet = workbook.Sheets[name];
+                            // Convert to array of arrays, limiting to first 1000 rows for performance
+                            const jsonData = XLSX.utils.sheet_to_json<(string | number | boolean | null)[]>(worksheet, { 
+                                header: 1,
+                                defval: ''
+                            });
+                            return {
+                                name,
+                                data: jsonData.slice(0, 1000) // Limit rows for performance
+                            };
+                        });
+                        setExcelSheets(sheets);
+                    } catch (err) {
+                        console.error('Failed to parse Excel file:', err);
+                        setMediaError('Failed to parse Excel file. Try downloading instead.');
+                    }
+                })
+                .catch(err => {
+                    console.error('Failed to load Excel file', err);
+                    setMediaError('Failed to load file. Please try downloading instead.');
+                })
+                .finally(() => setLoading(false));
+        } else if (isPPTX) {
+            // PowerPoint file - show metadata and download option
+            // Full PPTX rendering requires complex libraries, so we show basic info
+            setLoading(true);
+            const previewUrl = file.url.includes('?') ? `${file.url}&preview=true` : `${file.url}?preview=true`;
+            fetch(previewUrl, {
+                headers: {
+                    'Authorization': `Bearer ${localStorage.getItem('auth_token') || sessionStorage.getItem('auth_token')}`
+                }
+            })
+                .then(res => {
+                    if (!res.ok) throw new Error('Failed to fetch file');
+                    return res.arrayBuffer();
+                })
+                .then(async buffer => {
+                    try {
+                        // Use JSZip-like approach to read PPTX (which is a ZIP file)
+                        const JSZip = (await import('jszip')).default;
+                        const zip = await JSZip.loadAsync(buffer);
+                        
+                        // Count slides by looking at ppt/slides/slide*.xml files
+                        let slideCount = 0;
+                        zip.forEach((relativePath) => {
+                            if (relativePath.match(/ppt\/slides\/slide\d+\.xml/)) {
+                                slideCount++;
+                            }
+                        });
+                        
+                        // Try to get title and author from core.xml
+                        let title: string | undefined;
+                        let author: string | undefined;
+                        const coreXml = zip.file('docProps/core.xml');
+                        if (coreXml) {
+                            const coreContent = await coreXml.async('text');
+                            const titleMatch = coreContent.match(/<dc:title>([^<]*)<\/dc:title>/);
+                            const authorMatch = coreContent.match(/<dc:creator>([^<]*)<\/dc:creator>/);
+                            title = titleMatch?.[1];
+                            author = authorMatch?.[1];
+                        }
+                        
+                        setPptxInfo({ slideCount, title, author });
+                    } catch (err) {
+                        console.error('Failed to parse PPTX file:', err);
+                        // Still show something useful
+                        setPptxInfo({ slideCount: 0, title: file.name });
+                    }
+                })
+                .catch(err => {
+                    console.error('Failed to load PPTX file', err);
                     setMediaError('Failed to load file. Please try downloading instead.');
                 })
                 .finally(() => setLoading(false));
@@ -109,16 +226,19 @@ export function FilePreviewModal({ isOpen, onClose, file }: FilePreviewModalProp
 
     if (!isOpen || !file) return null;
 
+    const fileName = file.name.toLowerCase();
     const isImage = file.type === 'image';
     const isVideo = file.type === 'video';
     const isAudio = file.type === 'audio';
-    const isPDF = file.name.toLowerCase().endsWith('.pdf');
-    const isCSV = file.name.toLowerCase().endsWith('.csv');
-    const isText = file.name.toLowerCase().endsWith('.txt') ||
-        file.name.toLowerCase().endsWith('.md') ||
-        file.name.toLowerCase().endsWith('.json') ||
-        file.name.toLowerCase().endsWith('.xml') ||
-        file.name.toLowerCase().endsWith('.log');
+    const isPDF = fileName.endsWith('.pdf');
+    const isCSV = fileName.endsWith('.csv');
+    const isText = fileName.endsWith('.txt') ||
+        fileName.endsWith('.md') ||
+        fileName.endsWith('.json') ||
+        fileName.endsWith('.xml') ||
+        fileName.endsWith('.log');
+    const isExcel = fileName.endsWith('.xlsx') || fileName.endsWith('.xls');
+    const isPPTX = fileName.endsWith('.pptx') || fileName.endsWith('.ppt');
 
     return (
         <div className="fixed inset-0 z-[60] overflow-y-auto bg-black bg-opacity-90 flex items-center justify-center p-4">
@@ -247,6 +367,109 @@ export function FilePreviewModal({ isOpen, onClose, file }: FilePreviewModalProp
                                     {textContent}
                                 </pre>
                             )}
+                        </div>
+                    ) : isExcel && excelSheets.length > 0 ? (
+                        <div className="w-full h-full flex flex-col bg-white dark:bg-gray-800 shadow-lg rounded-lg overflow-hidden">
+                            {/* Sheet tabs */}
+                            {excelSheets.length > 1 && (
+                                <div className="flex items-center gap-1 px-4 py-2 bg-gray-100 dark:bg-gray-700 border-b border-gray-200 dark:border-gray-600 overflow-x-auto">
+                                    <FileSpreadsheet className="w-4 h-4 text-green-600 mr-2 flex-shrink-0" />
+                                    {excelSheets.map((sheet, idx) => (
+                                        <button
+                                            key={sheet.name}
+                                            onClick={() => setSelectedSheetIndex(idx)}
+                                            className={`px-3 py-1.5 text-sm font-medium rounded-t whitespace-nowrap transition-colors ${
+                                                selectedSheetIndex === idx
+                                                    ? 'bg-white dark:bg-gray-800 text-primary-600 dark:text-primary-400 border-t border-x border-gray-200 dark:border-gray-600'
+                                                    : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                                            }`}
+                                        >
+                                            {sheet.name}
+                                        </button>
+                                    ))}
+                                </div>
+                            )}
+                            {/* Spreadsheet content */}
+                            <div className="flex-1 overflow-auto p-4">
+                                <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700 border border-gray-200 dark:border-gray-700">
+                                    <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
+                                        {excelSheets[selectedSheetIndex]?.data.map((row, i) => (
+                                            <tr key={i} className={i === 0 ? "bg-gray-50 dark:bg-gray-700 font-semibold" : "hover:bg-gray-50 dark:hover:bg-gray-700/50"}>
+                                                {/* Row number */}
+                                                <td className="px-2 py-2 text-xs text-gray-400 dark:text-gray-500 bg-gray-50 dark:bg-gray-700/50 border-r border-gray-200 dark:border-gray-600 text-center w-10">
+                                                    {i + 1}
+                                                </td>
+                                                {row.map((cell, j) => (
+                                                    <td 
+                                                        key={j} 
+                                                        className="px-3 py-2 text-sm text-gray-700 dark:text-gray-300 border-r border-gray-100 dark:border-gray-700 last:border-none whitespace-nowrap max-w-xs truncate"
+                                                        title={String(cell ?? '')}
+                                                    >
+                                                        {cell !== null && cell !== undefined ? String(cell) : ''}
+                                                    </td>
+                                                ))}
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </table>
+                                {excelSheets[selectedSheetIndex]?.data.length >= 1000 && (
+                                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-2 text-center">
+                                        Showing first 1,000 rows. Download for full content.
+                                    </p>
+                                )}
+                            </div>
+                        </div>
+                    ) : isPPTX && pptxInfo ? (
+                        <div className="w-full max-w-md bg-white dark:bg-gray-800 rounded-xl shadow-lg p-8 text-center">
+                            <div className="mb-6">
+                                <div className="w-20 h-20 mx-auto bg-orange-100 dark:bg-orange-900/30 rounded-2xl flex items-center justify-center mb-4">
+                                    <Presentation className="w-10 h-10 text-orange-600 dark:text-orange-400" />
+                                </div>
+                                <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">
+                                    {pptxInfo.title || file.name}
+                                </h3>
+                                {pptxInfo.author && (
+                                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                                        by {pptxInfo.author}
+                                    </p>
+                                )}
+                            </div>
+                            
+                            <div className="flex items-center justify-center gap-6 mb-6 text-gray-600 dark:text-gray-400">
+                                <div className="flex items-center gap-2">
+                                    <div className="flex items-center justify-center w-8 h-8 bg-gray-100 dark:bg-gray-700 rounded-lg">
+                                        <ChevronLeft className="w-4 h-4" />
+                                        <ChevronRight className="w-4 h-4 -ml-2" />
+                                    </div>
+                                    <span className="text-2xl font-bold text-gray-900 dark:text-white">
+                                        {pptxInfo.slideCount}
+                                    </span>
+                                    <span className="text-sm">slides</span>
+                                </div>
+                            </div>
+                            
+                            <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+                                PowerPoint preview requires download. Click below to open in your preferred application.
+                            </p>
+                            
+                            <button
+                                onClick={async () => {
+                                    const response = await fetch(file.url, {
+                                        headers: { 'Authorization': `Bearer ${localStorage.getItem('auth_token') || sessionStorage.getItem('auth_token')}` }
+                                    });
+                                    const blob = await response.blob();
+                                    const url = URL.createObjectURL(blob);
+                                    const a = document.createElement('a');
+                                    a.href = url;
+                                    a.download = file.name;
+                                    a.click();
+                                    URL.revokeObjectURL(url);
+                                }}
+                                className="inline-flex items-center px-6 py-3 border border-transparent text-sm font-medium rounded-lg shadow-sm text-white bg-orange-600 hover:bg-orange-700 transition-colors"
+                            >
+                                <Download className="w-4 h-4 mr-2" />
+                                Download Presentation
+                            </button>
                         </div>
                     ) : (
                         <div className="text-center">


### PR DESCRIPTION
Implemented server-side preview for Excel and PowerPoint files via a new /api/preview endpoint, with frontend support for spreadsheet and PPTX metadata display. Updated documentation and README to include new AI features and File Groups, and improved file preview logic in the frontend. Added xlsx and jszip dependencies for client-side Excel and PPTX handling.